### PR TITLE
Static Site Module update - full release of working module

### DIFF
--- a/modules/products/static-site/WAF.tf
+++ b/modules/products/static-site/WAF.tf
@@ -1,7 +1,7 @@
 resource "aws_wafv2_web_acl" "default" {
   name        = "cc-static-site-${var.tags.product}-${var.tags.component}"
   description = "Static Site WAF rule for ${var.tags.product} ${var.tags.component}"
-  scope       = "REGIONAL"
+  scope       = "CLOUDWATCH"
 
   tags = local.common_tags
 

--- a/modules/products/static-site/WAF.tf
+++ b/modules/products/static-site/WAF.tf
@@ -1,6 +1,6 @@
 resource "aws_wafv2_web_acl" "default" {
-  name        = "cc-static-site-${var.tags.product}-${var.tags.component}"
-  description = "Static Site WAF rule for ${var.tags.product} ${var.tags.component}"
+  name        = "cc-static-site-${var.tenant_vars.product}-${var.tenant_vars.component}"
+  description = "Static Site WAF rule for ${var.tenant_vars.product} ${var.tenant_vars.component}"
   scope       = "CLOUDFRONT"
   provider    = aws.us-east-1
 
@@ -12,7 +12,7 @@ resource "aws_wafv2_web_acl" "default" {
 
   visibility_config {
     cloudwatch_metrics_enabled = false
-    metric_name                = "static-site-${var.tags.product}-${var.tags.component}"
+    metric_name                = "static-site-${var.tenant_vars.product}-${var.tenant_vars.component}"
     sampled_requests_enabled   = false
   }
 

--- a/modules/products/static-site/WAF.tf
+++ b/modules/products/static-site/WAF.tf
@@ -2,6 +2,7 @@ resource "aws_wafv2_web_acl" "default" {
   name        = "cc-static-site-${var.tags.product}-${var.tags.component}"
   description = "Static Site WAF rule for ${var.tags.product} ${var.tags.component}"
   scope       = "CLOUDFRONT"
+  provider    = aws.us-east-1
 
   tags = local.common_tags
 

--- a/modules/products/static-site/WAF.tf
+++ b/modules/products/static-site/WAF.tf
@@ -1,7 +1,7 @@
 resource "aws_wafv2_web_acl" "default" {
   name        = "cc-static-site-${var.tags.product}-${var.tags.component}"
   description = "Static Site WAF rule for ${var.tags.product} ${var.tags.component}"
-  scope       = "CLOUDWATCH"
+  scope       = "CLOUDFRONT"
 
   tags = local.common_tags
 

--- a/modules/products/static-site/cloudfront.tf
+++ b/modules/products/static-site/cloudfront.tf
@@ -1,6 +1,6 @@
 resource "aws_cloudfront_origin_access_control" "static_site_identity" {
-  name                              = "cc-static-site-${var.tags.product}-${var.tags.component}"
-  description                       = "Origin access control for ${var.tags.product} ${var.tags.component}"
+  name                              = "cc-static-site-${var.tenant_vars.product}-${var.tenant_vars.component}"
+  description                       = "Origin access control for ${var.tenant_vars.product} ${var.tenant_vars.component}"
   origin_access_control_origin_type = "s3"
   signing_behavior                  = "always"
   signing_protocol                  = "sigv4"
@@ -15,7 +15,7 @@ resource "aws_cloudfront_distribution" "static_site_distribution" {
 
   enabled             = true
   is_ipv6_enabled     = true
-  comment             = "Cloudfront distribution for ${var.tags.product} ${var.tags.component}"
+  comment             = "Cloudfront distribution for ${var.tenant_vars.product} ${var.tenant_vars.component}"
   default_root_object = "index.html"
 
   # logging_config {
@@ -24,7 +24,7 @@ resource "aws_cloudfront_distribution" "static_site_distribution" {
   #   prefix          = "myprefix"
   # }
 
-  aliases = var.cloud_front_vars.cloudfront_aliases
+  aliases = var.tenant_vars.cloudfront_aliases
 
   default_cache_behavior {
     allowed_methods  = ["DELETE", "GET", "HEAD", "OPTIONS", "PATCH", "POST", "PUT"]
@@ -51,12 +51,12 @@ resource "aws_cloudfront_distribution" "static_site_distribution" {
     }
   }
 
-  price_class = var.cloud_front_vars.cloudfront_price_class
+  price_class = var.cloud_front_default_vars.cloudfront_price_class
 
   tags = local.common_tags
 
   viewer_certificate {
-    acm_certificate_arn            = var.cloud_front_vars.cloudfront_cert
+    acm_certificate_arn            = var.tenant_vars.cloudfront_cert
     minimum_protocol_version       = "TLSv1.2_2021"
     cloudfront_default_certificate = "false"
     ssl_support_method             = "sni-only"

--- a/modules/products/static-site/cloudfront.tf
+++ b/modules/products/static-site/cloudfront.tf
@@ -58,5 +58,5 @@ resource "aws_cloudfront_distribution" "static_site_distribution" {
     cloudfront_default_certificate = true
     minimum_protocol_version       = "TLSv1.2_2021"
   }
-  web_acl_id = aws_wafv2_web_acl.default.id
+  web_acl_id = aws_wafv2_web_acl.default.arn
 }

--- a/modules/products/static-site/cloudfront.tf
+++ b/modules/products/static-site/cloudfront.tf
@@ -55,7 +55,7 @@ resource "aws_cloudfront_distribution" "static_site_distribution" {
   tags = local.common_tags
 
   viewer_certificate {
-    acm_certificate_arn      = cloud_front_vars.cloudfront_cert
+    acm_certificate_arn      = var.cloud_front_vars.cloudfront_cert
     minimum_protocol_version = "TLSv1.2_2021"
   }
   web_acl_id = aws_wafv2_web_acl.default.arn

--- a/modules/products/static-site/cloudfront.tf
+++ b/modules/products/static-site/cloudfront.tf
@@ -55,8 +55,9 @@ resource "aws_cloudfront_distribution" "static_site_distribution" {
   tags = local.common_tags
 
   viewer_certificate {
-    acm_certificate_arn      = var.cloud_front_vars.cloudfront_cert
-    minimum_protocol_version = "TLSv1.2_2021"
+    acm_certificate_arn            = var.cloud_front_vars.cloudfront_cert
+    minimum_protocol_version       = "TLSv1.2_2021"
+    cloudfront_default_certificate = "false"
   }
   web_acl_id = aws_wafv2_web_acl.default.arn
 }

--- a/modules/products/static-site/cloudfront.tf
+++ b/modules/products/static-site/cloudfront.tf
@@ -58,6 +58,7 @@ resource "aws_cloudfront_distribution" "static_site_distribution" {
     acm_certificate_arn            = var.cloud_front_vars.cloudfront_cert
     minimum_protocol_version       = "TLSv1.2_2021"
     cloudfront_default_certificate = "false"
+    ssl_support_method             = "sni-only"
   }
   web_acl_id = aws_wafv2_web_acl.default.arn
 }

--- a/modules/products/static-site/cloudfront.tf
+++ b/modules/products/static-site/cloudfront.tf
@@ -55,8 +55,8 @@ resource "aws_cloudfront_distribution" "static_site_distribution" {
   tags = local.common_tags
 
   viewer_certificate {
-    cloudfront_default_certificate = true
-    minimum_protocol_version       = "TLSv1.2_2021"
+    acm_certificate_arn      = cloud_front_vars.cloudfront_cert
+    minimum_protocol_version = "TLSv1.2_2021"
   }
   web_acl_id = aws_wafv2_web_acl.default.arn
 }

--- a/modules/products/static-site/cloudfront.tf
+++ b/modules/products/static-site/cloudfront.tf
@@ -8,8 +8,9 @@ resource "aws_cloudfront_origin_access_control" "static_site_identity" {
 
 resource "aws_cloudfront_distribution" "static_site_distribution" {
   origin {
-    domain_name = aws_s3_bucket.static_site.bucket_regional_domain_name
-    origin_id   = aws_s3_bucket.static_site.id
+    domain_name              = aws_s3_bucket.static_site.bucket_regional_domain_name
+    origin_id                = aws_s3_bucket.static_site.id
+    origin_access_control_id = aws_cloudfront_origin_access_control.static_site_identity.id
   }
 
   enabled             = true

--- a/modules/products/static-site/iam.tf
+++ b/modules/products/static-site/iam.tf
@@ -5,7 +5,7 @@ locals {
 }
 
 resource "aws_iam_role" "static_site_actions_push" {
-  name = "cc-static-site-${var.tags.product}-${var.tags.component}"
+  name = "cc-static-site-${var.tenant_vars.product}-${var.tenant_vars.component}"
   assume_role_policy = jsonencode({
     Version = "2012-10-17"
     Statement = [
@@ -18,7 +18,7 @@ resource "aws_iam_role" "static_site_actions_push" {
         }
         Condition = {
           StringLike = {
-            "token.actions.githubusercontent.com:sub" : var.tags.repository
+            "token.actions.githubusercontent.com:sub" : var.tenant_vars.repository
             "sts:RoleSessionName" : "GitHubActions"
           }
           StringEquals = {

--- a/modules/products/static-site/iam.tf
+++ b/modules/products/static-site/iam.tf
@@ -7,30 +7,29 @@ locals {
 resource "aws_iam_role" "static_site_actions_push" {
   name = "cc-static-site-${var.tags.product}-${var.tags.component}"
   assume_role_policy = jsonencode({
-    Version = "2012-10-17"
+    Version = "2012-10-17",
     Statement = [
       {
-        Action = "sts:AssumeRoleWithWebIdentity"
-        Effect = "Allow"
-        Sid    = ""
+        Action = "sts:AssumeRoleWithWebIdentity",
+        Effect = "Allow",
+        Sid    = "",
         Principal = {
-          Federated : "arn:aws:iam::${local.account_id}:oidc-provider/token.actions.githubusercontent.com"
-        }
+          Federated = "arn:aws:iam::${local.account_id}:oidc-provider/token.actions.githubusercontent.com"
+        },
         Condition = {
           StringLike = {
-            "token.actions.githubusercontent.com:sub:" : var.tags.repository
-            "sts:RoleSessionName" : "GitHubActions"
-          }
+            "token.actions.githubusercontent.com:sub" : var.tags.repository
+          },
           StringEquals = {
-            "token.actions.githubusercontent.com:aud:" : "sts.amazonaws.com"
+            "token.actions.githubusercontent.com:aud" : "sts.amazonaws.com"
           }
-        },
+        }
       }
     ]
   })
-
   tags = local.common_tags
 }
+
 
 resource "aws_iam_role_policy_attachment" "static_site_policy_attachment" {
   policy_arn = aws_iam_policy.static_site_policy.arn

--- a/modules/products/static-site/iam.tf
+++ b/modules/products/static-site/iam.tf
@@ -1,3 +1,9 @@
+data "aws_caller_identity" "current" {}
+
+locals {
+  account_id = data.aws_caller_identity.current.account_id
+}
+
 resource "aws_iam_role" "static_site_actions_push" {
   name = "cc-static-site-${var.tags.product}-${var.tags.component}"
   assume_role_policy = jsonencode({
@@ -8,7 +14,7 @@ resource "aws_iam_role" "static_site_actions_push" {
         Effect = "Allow"
         Sid    = ""
         Principal = {
-          Federated : "*"
+          Federated : "arn:aws:iam::${local.account_id}:oidc-provider/token.actions.githubusercontent.com"
         }
         Condition = {
           StringLike = {

--- a/modules/products/static-site/iam.tf
+++ b/modules/products/static-site/iam.tf
@@ -18,11 +18,11 @@ resource "aws_iam_role" "static_site_actions_push" {
         }
         Condition = {
           StringLike = {
-            "token.actions.githubusercontent.com:sub:" : var.tags.repository
+            "token.actions.githubusercontent.com:sub" : var.tags.repository
             "sts:RoleSessionName" : "GitHubActions"
           }
           StringEquals = {
-            "token.actions.githubusercontent.com:aud:" : "sts.amazonaws.com"
+            "token.actions.githubusercontent.com:aud" : "sts.amazonaws.com"
           }
         },
       }

--- a/modules/products/static-site/iam.tf
+++ b/modules/products/static-site/iam.tf
@@ -7,23 +7,24 @@ locals {
 resource "aws_iam_role" "static_site_actions_push" {
   name = "cc-static-site-${var.tags.product}-${var.tags.component}"
   assume_role_policy = jsonencode({
-    Version = "2012-10-17",
+    Version = "2012-10-17"
     Statement = [
       {
-        Action = "sts:AssumeRoleWithWebIdentity",
-        Effect = "Allow",
-        Sid    = "",
+        Action = "sts:AssumeRoleWithWebIdentity"
+        Effect = "Allow"
+        Sid    = ""
         Principal = {
-          Federated = "arn:aws:iam::${local.account_id}:oidc-provider/token.actions.githubusercontent.com"
-        },
+          Federated : "arn:aws:iam::${local.account_id}:oidc-provider/token.actions.githubusercontent.com"
+        }
         Condition = {
           StringLike = {
-            "token.actions.githubusercontent.com:sub" : var.tags.repository
-          },
-          StringEquals = {
-            "token.actions.githubusercontent.com:aud" : "sts.amazonaws.com"
+            "token.actions.githubusercontent.com:sub:" : var.tags.repository
+            "sts:RoleSessionName" : "GitHubActions"
           }
-        }
+          StringEquals = {
+            "token.actions.githubusercontent.com:aud:" : "sts.amazonaws.com"
+          }
+        },
       }
     ]
   })

--- a/modules/products/static-site/main.tf
+++ b/modules/products/static-site/main.tf
@@ -2,9 +2,9 @@
 
 locals {
   common_tags = {
-    COST_CENTRE = var.tags.COST_CENTRE
-    PRODUCT     = var.tags.product
-    COMPONENT   = var.tags.component
+    COST_CENTRE = var.tenant_vars.COST_CENTRE
+    PRODUCT     = var.tenant_vars.product
+    COMPONENT   = var.tenant_vars.component
   }
 }
 

--- a/modules/products/static-site/main.tf
+++ b/modules/products/static-site/main.tf
@@ -7,3 +7,8 @@ locals {
     COMPONENT   = var.tags.component
   }
 }
+
+provider "aws" {
+  region = "us-east-1"
+  alias  = "us-east-1"
+}

--- a/modules/products/static-site/storage.tf
+++ b/modules/products/static-site/storage.tf
@@ -1,5 +1,5 @@
 resource "aws_s3_bucket" "static_site" {
-  bucket = var.domain
+  bucket = "cc-static-site-${var.tags.product}-${var.tags.component}"
 
   tags = local.common_tags
 }

--- a/modules/products/static-site/storage.tf
+++ b/modules/products/static-site/storage.tf
@@ -4,17 +4,17 @@ resource "aws_s3_bucket" "static_site" {
   tags = local.common_tags
 }
 
-resource "aws_s3_bucket_website_configuration" "static_site_config" {
-  bucket = aws_s3_bucket.static_site.id
+# resource "aws_s3_bucket_website_configuration" "static_site_config" {
+#   bucket = aws_s3_bucket.static_site.id
 
-  index_document {
-    suffix = "index.html"
-  }
+#   index_document {
+#     suffix = "index.html"
+#   }
 
-  error_document {
-    key = "error.html"
-  }
-}
+#   error_document {
+#     key = "error.html"
+#   }
+# }
 
 resource "aws_s3_bucket_public_access_block" "static_site_acl" {
   bucket = aws_s3_bucket.static_site.id

--- a/modules/products/static-site/storage.tf
+++ b/modules/products/static-site/storage.tf
@@ -1,5 +1,5 @@
 resource "aws_s3_bucket" "static_site" {
-  bucket = "cc-static-site-${var.tags.product}-${var.tags.component}"
+  bucket = var.domain
 
   tags = local.common_tags
 }

--- a/modules/products/static-site/storage.tf
+++ b/modules/products/static-site/storage.tf
@@ -1,20 +1,8 @@
 resource "aws_s3_bucket" "static_site" {
-  bucket = "cc-static-site-${var.tags.product}-${var.tags.component}"
+  bucket = "cc-static-site-${var.tenant_vars.product}-${var.tenant_vars.component}"
 
   tags = local.common_tags
 }
-
-# resource "aws_s3_bucket_website_configuration" "static_site_config" {
-#   bucket = aws_s3_bucket.static_site.id
-
-#   index_document {
-#     suffix = "index.html"
-#   }
-
-#   error_document {
-#     key = "error.html"
-#   }
-# }
 
 resource "aws_s3_bucket_public_access_block" "static_site_acl" {
   bucket = aws_s3_bucket.static_site.id

--- a/modules/products/static-site/variables.tf
+++ b/modules/products/static-site/variables.tf
@@ -10,6 +10,6 @@ variable "aws_region" {
   type = string
 }
 
-variable "domain" {
-  type = string
-}
+# variable "domain" {
+#   type = string
+# }

--- a/modules/products/static-site/variables.tf
+++ b/modules/products/static-site/variables.tf
@@ -9,3 +9,7 @@ variable "cloud_front_vars" {
 variable "aws_region" {
   type = string
 }
+
+variable "domain" {
+  type = string
+}

--- a/modules/products/static-site/variables.tf
+++ b/modules/products/static-site/variables.tf
@@ -1,15 +1,11 @@
-variable "tags" {
+variable "tenant_vars" {
   type = any
 }
 
-variable "cloud_front_vars" {
+variable "cloud_front_default_vars" {
   type = any
 }
 
 variable "aws_region" {
   type = string
 }
-
-# variable "domain" {
-#   type = string
-# }


### PR DESCRIPTION
Changelog:

- Cloudfront scope change from [scope = "REGIONAL"] to [scope  = "CLOUDFRONT"]
- Updated input variables to match multi-tenant workflow from terragrunt repo
- add origin_access_control_id  into the module and as an input
- change cloudfront_default_certificate to false
- add acm_certificate_arn as an input
- add us-east-1 as provider for cloudfront
- updated federated arn for principal
- remove trailing : from conditions of github policy
- remove aws_s3_bucket_website_configuration