### PR TITLE
CCL-1101 Create Opt-In Mechanism for Kinesis Firehose

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,3 +32,5 @@ override.tf.json
 # Ignore CLI configuration files
 .terraformrc
 terraform.rc
+
+*.zip

--- a/modules/aws/logging/cwl_subscribe_with_tags/.terraform-docs.yml
+++ b/modules/aws/logging/cwl_subscribe_with_tags/.terraform-docs.yml
@@ -1,0 +1,38 @@
+formatter: markdown
+
+output:
+  file: README.md
+  mode: replace
+
+content: |
+  # CloudWatch Logs Subscribe With Tags
+  
+  A terraform module that creates an EventBridge rule which listens for tag changes on Cloud Watch log groups.
+  
+  If a tag matching a user-defined pattern is found, and the tag value matches the "opt-in" user-defined pattern, then
+  a subscription filter will be added to the Log Group in order to forward the logs to a user-defined destination.
+  
+  A good use-case for this module is to selectively forward certain logs to a Kinesis stream for onward ingestion into Splunk,
+  or to ensure that certain logs get forwarded to a destination for long-term S3 archival.
+  
+  ## Example usage
+  ```hcl
+  module "cwl-subscribe-with-tag" {
+    source                          = "./cwl-subscribe-with-tag"
+    name                            = "send-to-splunk"
+    tag_pattern                     = "splunk"
+    cloudwatch_logs_destination_arn = aws_cloudwatch_log_destination.kinesis.arn
+  }
+  ```
+  {{ .Providers }}
+  {{ .Resources }}
+  {{ .Inputs }}
+  {{ .Footer }}
+settings:
+  sections:
+    - header
+    - providers
+    - resources
+    - inputs
+    - outputs
+    - footer

--- a/modules/aws/logging/cwl_subscribe_with_tags/.tflint.hcl
+++ b/modules/aws/logging/cwl_subscribe_with_tags/.tflint.hcl
@@ -1,0 +1,10 @@
+plugin "terraform" {
+  enabled = true
+  preset  = "recommended"
+}
+
+plugin "aws" {
+  enabled = true
+  version = "0.35.0"
+  source  = "github.com/terraform-linters/tflint-ruleset-aws"
+}

--- a/modules/aws/logging/cwl_subscribe_with_tags/README.md
+++ b/modules/aws/logging/cwl_subscribe_with_tags/README.md
@@ -1,0 +1,60 @@
+<!-- BEGIN_TF_DOCS -->
+# CloudWatch Logs Subscribe With Tags
+
+A terraform module that creates an EventBridge rule which listens for tag changes on Cloud Watch log groups.
+
+If a tag matching a user-defined pattern is found, and the tag value matches the "opt-in" user-defined pattern, then
+a subscription filter will be added to the Log Group in order to forward the logs to a user-defined destination.
+
+A good use-case for this module is to selectively forward certain logs to a Kinesis stream for onward ingestion into Splunk,
+or to ensure that certain logs get forwarded to a destination for long-term S3 archival.
+
+## Example usage
+```hcl
+module "cwl-subscribe-with-tag" {
+  source                          = "./cwl-subscribe-with-tag"
+  name                            = "send-to-splunk"
+  tag_pattern                     = "splunk"
+  cloudwatch_logs_destination_arn = aws_cloudwatch_log_destination.kinesis.arn
+}
+```
+## Providers
+
+| Name | Version |
+|------|---------|
+| <a name="provider_archive"></a> [archive](#provider\_archive) | 2.6.0 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | 5.54.1 |
+## Resources
+
+| Name | Type |
+|------|------|
+| [aws_cloudwatch_event_rule.this](https://registry.terraform.io/providers/hashicorp/aws/5.54.1/docs/resources/cloudwatch_event_rule) | resource |
+| [aws_cloudwatch_event_target.this](https://registry.terraform.io/providers/hashicorp/aws/5.54.1/docs/resources/cloudwatch_event_target) | resource |
+| [aws_cloudwatch_log_group.this](https://registry.terraform.io/providers/hashicorp/aws/5.54.1/docs/resources/cloudwatch_log_group) | resource |
+| [aws_iam_policy.lambda](https://registry.terraform.io/providers/hashicorp/aws/5.54.1/docs/resources/iam_policy) | resource |
+| [aws_iam_policy.lambda_code](https://registry.terraform.io/providers/hashicorp/aws/5.54.1/docs/resources/iam_policy) | resource |
+| [aws_iam_role.lambda](https://registry.terraform.io/providers/hashicorp/aws/5.54.1/docs/resources/iam_role) | resource |
+| [aws_iam_role.lambda_code](https://registry.terraform.io/providers/hashicorp/aws/5.54.1/docs/resources/iam_role) | resource |
+| [aws_iam_role_policy_attachment.lambda](https://registry.terraform.io/providers/hashicorp/aws/5.54.1/docs/resources/iam_role_policy_attachment) | resource |
+| [aws_iam_role_policy_attachment.lambda_code](https://registry.terraform.io/providers/hashicorp/aws/5.54.1/docs/resources/iam_role_policy_attachment) | resource |
+| [aws_lambda_function.this](https://registry.terraform.io/providers/hashicorp/aws/5.54.1/docs/resources/lambda_function) | resource |
+| [aws_lambda_permission.this](https://registry.terraform.io/providers/hashicorp/aws/5.54.1/docs/resources/lambda_permission) | resource |
+| [archive_file.this](https://registry.terraform.io/providers/hashicorp/archive/2.6.0/docs/data-sources/file) | data source |
+| [aws_caller_identity.current](https://registry.terraform.io/providers/hashicorp/aws/5.54.1/docs/data-sources/caller_identity) | data source |
+| [aws_iam_policy_document.lambda](https://registry.terraform.io/providers/hashicorp/aws/5.54.1/docs/data-sources/iam_policy_document) | data source |
+| [aws_iam_policy_document.lambda-assume](https://registry.terraform.io/providers/hashicorp/aws/5.54.1/docs/data-sources/iam_policy_document) | data source |
+| [aws_iam_policy_document.lambda_code](https://registry.terraform.io/providers/hashicorp/aws/5.54.1/docs/data-sources/iam_policy_document) | data source |
+| [aws_iam_policy_document.lambda_code_assume](https://registry.terraform.io/providers/hashicorp/aws/5.54.1/docs/data-sources/iam_policy_document) | data source |
+| [aws_region.current](https://registry.terraform.io/providers/hashicorp/aws/5.54.1/docs/data-sources/region) | data source |
+## Inputs
+
+| Name | Description | Type | Default | Required |
+|------|-------------|------|---------|:--------:|
+| <a name="input_cloudwatch_logs_destination_arn"></a> [cloudwatch\_logs\_destination\_arn](#input\_cloudwatch\_logs\_destination\_arn) | The Arn of the CloudWatch logs destination. | `string` | n/a | yes |
+| <a name="input_log_retention_in_days"></a> [log\_retention\_in\_days](#input\_log\_retention\_in\_days) | The number of days retention for lambda CloudWatch log group. | `number` | `731` | no |
+| <a name="input_name"></a> [name](#input\_name) | The name of the lambda function and subscription filter. | `string` | n/a | yes |
+| <a name="input_opt_in_tag_value"></a> [opt\_in\_tag\_value](#input\_opt\_in\_tag\_value) | The tag value which indicates opting-in. | `string` | `"true"` | no |
+| <a name="input_opt_out_tag_value"></a> [opt\_out\_tag\_value](#input\_opt\_out\_tag\_value) | The tag value which indicates opting-out. | `string` | `"false"` | no |
+| <a name="input_tag_pattern"></a> [tag\_pattern](#input\_tag\_pattern) | The tag pattern to match on. | `string` | n/a | yes |
+
+<!-- END_TF_DOCS -->

--- a/modules/aws/logging/cwl_subscribe_with_tags/cloudwatch_event.tf
+++ b/modules/aws/logging/cwl_subscribe_with_tags/cloudwatch_event.tf
@@ -1,0 +1,32 @@
+resource "aws_cloudwatch_event_rule" "this" {
+  name        = var.name
+  description = "invoked on cloudwatch log group tag changes"
+
+  event_pattern = jsonencode(
+    {
+      "source" : [
+        "aws.tag"
+      ],
+      "detail-type" : [
+        "Tag Change on Resource"
+      ],
+      "detail" : {
+        "service" : [
+          "logs"
+        ],
+        "tags" : {
+          (var.tag_pattern) : [
+            var.opt_in_tag_value,
+            var.opt_out_tag_value
+          ]
+        }
+      }
+    }
+  )
+}
+
+resource "aws_cloudwatch_event_target" "this" {
+  rule      = aws_cloudwatch_event_rule.this.name
+  target_id = var.name
+  arn       = aws_lambda_function.this.arn
+}

--- a/modules/aws/logging/cwl_subscribe_with_tags/create-sub-filter/main.py
+++ b/modules/aws/logging/cwl_subscribe_with_tags/create-sub-filter/main.py
@@ -1,0 +1,46 @@
+import boto3
+import os
+
+
+def handler(event, context):
+    tag = os.environ.get("TAG")
+    opt_in = os.environ.get("OPT_IN")
+    opt_out = os.environ.get('OPT_OUT')
+    tag_value = event['detail']['tags'][tag]
+    filter_name = os.environ.get("FILTER_NAME")
+    filter_pattern = ""  # leave blank to capture all
+    destination_arn = os.environ.get("DESTINATION_ARN")
+    role_arn = os.environ.get("ROLE_ARN")
+    source = event['source']
+    detail_type = event['detail-type']
+
+    print(f"destination={destination_arn}")
+
+    if source == 'aws.tag' and detail_type == 'Tag Change on Resource':
+        log_group_arn = event['resources'][0]
+        log_group_name = log_group_arn.split(":")[-1]
+        print(f"{log_group_name} is tagged with {tag} = {tag_value}")
+
+        logs_client = boto3.client("logs")
+
+        if tag_value == opt_in:
+            response = logs_client.put_subscription_filter(
+                logGroupName=log_group_name,
+                filterName=filter_name,
+                filterPattern=filter_pattern,
+                destinationArn=destination_arn,
+                roleArn=role_arn
+            )
+
+            print(f"{filter_name} subscription filter added to {log_group_name}")
+
+        elif tag_value == opt_out:
+            response = logs_client.delete_subscription_filter(
+                logGroupName=log_group_name,
+                filterName=filter_name
+            )
+
+            print(f"{filter_name} subscription filter removed from {log_group_name}")
+
+        else:
+            print("no change")

--- a/modules/aws/logging/cwl_subscribe_with_tags/data.tf
+++ b/modules/aws/logging/cwl_subscribe_with_tags/data.tf
@@ -1,0 +1,2 @@
+data "aws_caller_identity" "current" {}
+data "aws_region" "current" {}

--- a/modules/aws/logging/cwl_subscribe_with_tags/lambda.tf
+++ b/modules/aws/logging/cwl_subscribe_with_tags/lambda.tf
@@ -1,0 +1,144 @@
+data "archive_file" "this" {
+  type        = "zip"
+  output_path = "${path.module}/create-sub-filter.zip"
+  source_file = "create-sub-filter/main.py"
+}
+
+resource "aws_lambda_function" "this" {
+  filename         = data.archive_file.this.output_path
+  source_code_hash = data.archive_file.this.output_base64sha256
+  function_name    = var.name
+  description      = "Creates a subscription filter when an opt-in tag value is found."
+  role             = aws_iam_role.lambda.arn
+
+  package_type                   = "Zip"
+  handler                        = "main.handler"
+  runtime                        = "python3.9"
+  reserved_concurrent_executions = -1
+  timeout                        = 180
+  memory_size                    = 768
+  tracing_config {
+    mode = "Active"
+  }
+
+  environment {
+    variables = {
+      DESTINATION_ARN = var.cloudwatch_logs_destination_arn
+      ROLE_ARN        = aws_iam_role.lambda_code.arn
+      ACCOUNT_ID      = data.aws_caller_identity.current.account_id
+
+      FILTER_NAME = var.name
+      REGION      = data.aws_region.current.name
+      TAG         = var.tag_pattern
+      OPT_IN      = var.opt_in_tag_value
+      OPT_OUT     = var.opt_out_tag_value
+    }
+  }
+}
+
+resource "aws_lambda_permission" "this" {
+  statement_id  = "AllowExecutionFromEventBridge"
+  action        = "lambda:InvokeFunction"
+  function_name = aws_lambda_function.this.function_name
+  principal     = "events.amazonaws.com"
+  source_arn    = aws_cloudwatch_event_rule.this.arn
+}
+
+resource "aws_iam_role" "lambda" {
+  name               = "${var.name}-lambda-function"
+  description        = "Role that is assumed by ${var.name} lambda."
+  assume_role_policy = data.aws_iam_policy_document.lambda-assume.json
+}
+
+data "aws_iam_policy_document" "lambda-assume" {
+  statement {
+    effect = "Allow"
+
+    principals {
+      type = "Service"
+      identifiers = [
+        "lambda.amazonaws.com"
+      ]
+    }
+
+    actions = ["sts:AssumeRole"]
+  }
+}
+
+#tfsec:ignore:aws-cloudwatch-log-group-customer-key
+resource "aws_cloudwatch_log_group" "this" {
+  name              = "/aws/lambda/${var.name}"
+  retention_in_days = var.log_retention_in_days
+}
+
+resource "aws_iam_role_policy_attachment" "lambda" {
+  role       = aws_iam_role.lambda.id
+  policy_arn = aws_iam_policy.lambda.arn
+}
+
+resource "aws_iam_policy" "lambda" {
+  name   = "${var.name}-lambda-function"
+  policy = data.aws_iam_policy_document.lambda.json
+}
+
+data "aws_iam_policy_document" "lambda" {
+  statement {
+    effect = "Allow"
+    actions = [
+      "logs:PutSubscriptionFilter",
+      "logs:DeleteSubscriptionFilter",
+      "logs:CreateLogGroup",
+      "logs:CreateLogStream",
+      "logs:PutLogEvents"
+    ]
+
+    # tfsec:ignore:aws-iam-no-policy-wildcards
+    resources = [
+      "*"
+    ]
+  }
+}
+
+resource "aws_iam_role" "lambda_code" {
+  name = "${var.name}-lambda-code"
+
+  assume_role_policy = data.aws_iam_policy_document.lambda_code_assume.json
+}
+
+data "aws_iam_policy_document" "lambda_code_assume" {
+  statement {
+    effect = "Allow"
+    actions = ["sts:AssumeRole"]
+
+    principals {
+      type = "Service"
+      identifiers = [
+        "logs.amazonaws.com"
+      ]
+    }
+  }
+}
+
+resource "aws_iam_role_policy_attachment" "lambda_code" {
+  role       = aws_iam_role.lambda_code.id
+  policy_arn = aws_iam_policy.lambda_code.arn
+}
+
+resource "aws_iam_policy" "lambda_code" {
+  name   = "${var.name}-lambda-code"
+  policy = data.aws_iam_policy_document.lambda_code.json
+}
+
+data "aws_iam_policy_document" "lambda_code" {
+  statement {
+    effect = "Allow"
+    actions = [
+      "logs:PutSubscriptionFilter"
+    ]
+
+    # tfsec:ignore:aws-iam-no-policy-wildcards
+    resources = [
+      "*"
+    ]
+  }
+}

--- a/modules/aws/logging/cwl_subscribe_with_tags/terraform.tf
+++ b/modules/aws/logging/cwl_subscribe_with_tags/terraform.tf
@@ -1,0 +1,17 @@
+terraform {
+  required_version = ">=1.9.8"
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "5.54.1"
+    }
+    archive = {
+      source  = "hashicorp/archive"
+      version = "2.6.0"
+    }
+  }
+}
+
+provider "archive" {}
+
+provider "aws" {}

--- a/modules/aws/logging/cwl_subscribe_with_tags/test/dependencies.tf
+++ b/modules/aws/logging/cwl_subscribe_with_tags/test/dependencies.tf
@@ -1,0 +1,78 @@
+resource "aws_kinesis_stream" "stream" {
+  name            = "test-kinesis-stream"
+  encryption_type = "KMS"
+  kms_key_id      = aws_kms_key.kinesis.id
+
+  shard_level_metrics = [
+    "IncomingBytes",
+    "OutgoingBytes",
+  ]
+
+  stream_mode_details {
+    stream_mode = "ON_DEMAND"
+  }
+
+  tags = {
+    Environment = "Testing"
+    Owner       = "Sam"
+    Team        = "Andromeda"
+  }
+}
+
+resource "aws_kms_key" "kinesis" {
+  description         = "A key to encrypt kinesis traffic."
+  enable_key_rotation = true
+}
+
+resource "aws_iam_role" "cwl-to-kinesis-stream" {
+  name               = "CwlKinesisRole"
+  assume_role_policy = data.aws_iam_policy_document.assume-role.json
+}
+
+resource "aws_iam_role_policy" "allow-put-kinesis-stream" {
+  name   = "allow-put-kinesis-stream"
+  role   = aws_iam_role.cwl-to-kinesis-stream.id
+  policy = data.aws_iam_policy_document.allow-put-kinesis-stream.json
+}
+
+data "aws_iam_policy_document" "assume-role" {
+  statement {
+    effect = "Allow"
+    principals {
+      type = "Service"
+      identifiers = ["logs.amazonaws.com"]
+    }
+    actions = ["sts:AssumeRole"]
+  }
+}
+
+data "aws_iam_policy_document" "allow-put-kinesis-stream" {
+  statement {
+    effect = "Allow"
+    actions = ["kinesis:PutRecord"]
+    resources = [aws_kinesis_stream.stream.arn]
+  }
+}
+
+resource "aws_cloudwatch_log_destination" "kinesis" {
+  name       = "send-to-kinesis"
+  role_arn   = aws_iam_role.cwl-to-kinesis-stream.arn
+  target_arn = aws_kinesis_stream.stream.arn
+}
+
+resource "aws_cloudwatch_log_destination_policy" "destination_policy" {
+  destination_name = aws_cloudwatch_log_destination.kinesis.name
+  access_policy    = data.aws_iam_policy_document.destination-policy.json
+}
+
+data "aws_iam_policy_document" "destination-policy" {
+  statement {
+    effect = "Allow"
+    principals {
+      identifiers = [data.aws_caller_identity.current.account_id]
+      type = "AWS"
+    }
+    actions = ["logs:PutSubscriptionFilter"]
+    resources = [aws_cloudwatch_log_destination.kinesis.arn]
+  }
+}

--- a/modules/aws/logging/cwl_subscribe_with_tags/variables.tf
+++ b/modules/aws/logging/cwl_subscribe_with_tags/variables.tf
@@ -1,0 +1,32 @@
+variable "cloudwatch_logs_destination_arn" {
+  type        = string
+  description = "The Arn of the CloudWatch logs destination."
+}
+
+variable "name" {
+  type        = string
+  description = "The name of the lambda function and subscription filter."
+}
+
+variable "tag_pattern" {
+  type        = string
+  description = "The tag pattern to match on."
+}
+
+variable "opt_in_tag_value" {
+  type        = string
+  description = "The tag value which indicates opting-in."
+  default     = "true"
+}
+
+variable "opt_out_tag_value" {
+  type        = string
+  description = "The tag value which indicates opting-out."
+  default     = "false"
+}
+
+variable "log_retention_in_days" {
+  type        = number
+  description = "The number of days retention for lambda CloudWatch log group."
+  default     = 731
+}


### PR DESCRIPTION
Add a new terraform module which subscribes to a CloudWatch log group based on the presence of a tag and forwards to a CloudWatch logs destination (e.g. Kinesis).

This module will be integrated with the new bootstrap process (being actively developed), allowing tenants to selectively forward certain logs into the central logging account for ingestion into Splunk.