### PR TITLE
CCL-1905 - remove backup global settings resource

### DIFF
--- a/modules/aws/backup_vault/README.md
+++ b/modules/aws/backup_vault/README.md
@@ -17,7 +17,6 @@ No modules.
 
 | Name | Type |
 |------|------|
-| [aws_backup_global_settings.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/backup_global_settings) | resource |
 | [aws_backup_vault.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/backup_vault) | resource |
 | [aws_backup_vault_policy.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/backup_vault_policy) | resource |
 
@@ -27,7 +26,6 @@ No modules.
 |------|-------------|------|---------|:--------:|
 | <a name="input_backup_vault_kms_key_arn"></a> [backup\_vault\_kms\_key\_arn](#input\_backup\_vault\_kms\_key\_arn) | ARN of the KMS key used to protect the AWS Backup vault. | `string` | `null` | no |
 | <a name="input_backup_vault_policy_json"></a> [backup\_vault\_policy\_json](#input\_backup\_vault\_policy\_json) | Resource Policy JSON for the AWS Backup vault. | `string` | `""` | no |
-| <a name="input_enable_cross_account_backup"></a> [enable\_cross\_account\_backup](#input\_enable\_cross\_account\_backup) | Enable cross account backup? | `bool` | `false` | no |
 | <a name="input_name"></a> [name](#input\_name) | Name of the Backup Vault | `string` | n/a | yes |
 | <a name="input_tags"></a> [tags](#input\_tags) | Resource tags | `map(string)` | n/a | yes |
 

--- a/modules/aws/backup_vault/main.tf
+++ b/modules/aws/backup_vault/main.tf
@@ -10,10 +10,3 @@ resource "aws_backup_vault_policy" "this" {
   backup_vault_name = aws_backup_vault.this.name
   policy            = var.backup_vault_policy_json
 }
-
-resource "aws_backup_global_settings" "this" {
-  count = var.enable_cross_account_backup == true ? 1 : 0
-  global_settings = {
-    "isCrossAccountBackupEnabled" = "true"
-  }
-}

--- a/modules/aws/backup_vault/variables.tf
+++ b/modules/aws/backup_vault/variables.tf
@@ -15,12 +15,6 @@ variable "backup_vault_kms_key_arn" {
   default     = null
 }
 
-variable "enable_cross_account_backup" {
-  description = "Enable cross account backup?"
-  type = bool
-  default = false
-}
-
 variable "tags" {
   description = "Resource tags"
   type        = map(string)


### PR DESCRIPTION
Removing `aws_backup_global_settings` resource as it is a parameter that needs setting in the Management account only