### PR TITLE
Add resource policy to event bus.

### DIFF
--- a/modules/aws/event_bridge/event_bridge_rule/README.md
+++ b/modules/aws/event_bridge/event_bridge_rule/README.md
@@ -21,11 +21,17 @@ A good use-case for this module is to selectively forward security-hub findings 
     }
     ``` 
 
+## Requirements
+
+| Name | Version |
+|------|---------|
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | 5.81.0 |
+
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | n/a |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | 5.81.0 |
 
 ## Modules
 
@@ -35,11 +41,13 @@ No modules.
 
 | Name | Type |
 |------|------|
-| [aws_cloudwatch_event_bus.custom_event_bus](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudwatch_event_bus) | resource |
-| [aws_cloudwatch_event_rule.event_rule](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudwatch_event_rule) | resource |
-| [aws_cloudwatch_event_target.event_target](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudwatch_event_target) | resource |
-| [aws_iam_role.eventbridge_role](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role) | resource |
-| [aws_iam_role_policy.eventbridge_policy](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy) | resource |
+| [aws_cloudwatch_event_bus.custom_event_bus](https://registry.terraform.io/providers/hashicorp/aws/5.81.0/docs/resources/cloudwatch_event_bus) | resource |
+| [aws_cloudwatch_event_bus_policy.this](https://registry.terraform.io/providers/hashicorp/aws/5.81.0/docs/resources/cloudwatch_event_bus_policy) | resource |
+| [aws_cloudwatch_event_rule.event_rule](https://registry.terraform.io/providers/hashicorp/aws/5.81.0/docs/resources/cloudwatch_event_rule) | resource |
+| [aws_cloudwatch_event_target.event_target](https://registry.terraform.io/providers/hashicorp/aws/5.81.0/docs/resources/cloudwatch_event_target) | resource |
+| [aws_iam_role.eventbridge_role](https://registry.terraform.io/providers/hashicorp/aws/5.81.0/docs/resources/iam_role) | resource |
+| [aws_iam_role_policy.eventbridge_policy](https://registry.terraform.io/providers/hashicorp/aws/5.81.0/docs/resources/iam_role_policy) | resource |
+| [aws_iam_policy_document.this](https://registry.terraform.io/providers/hashicorp/aws/5.81.0/docs/data-sources/iam_policy_document) | data source |
 
 ## Inputs
 
@@ -52,6 +60,7 @@ No modules.
 | <a name="input_event_sources"></a> [event\_sources](#input\_event\_sources) | Event sources to match in the event pattern | `list(string)` | n/a | yes |
 | <a name="input_role_actions"></a> [role\_actions](#input\_role\_actions) | List of actions the IAM Role should allow | `list(string)` | n/a | yes |
 | <a name="input_role_name"></a> [role\_name](#input\_role\_name) | IAM Role name for EventBridge | `string` | n/a | yes |
+| <a name="input_source_account_id"></a> [source\_account\_id](#input\_source\_account\_id) | The source AWS Account ID where events are forwarded from | `string` | `""` | no |
 | <a name="input_target_arn"></a> [target\_arn](#input\_target\_arn) | ARN of the target for the event rule | `string` | n/a | yes |
 
 ## Outputs

--- a/modules/aws/event_bridge/event_bridge_rule/main.tf
+++ b/modules/aws/event_bridge/event_bridge_rule/main.tf
@@ -13,7 +13,7 @@ resource "aws_cloudwatch_event_bus" "custom_event_bus" {
 }
 
 data "aws_iam_policy_document" "this" {
-  count = var.source_event_bus_arn == "" ? 0 : 1
+  count = var.source_account_id == "" ? 0 : 1
   statement {
     sid    = "ActionsForResource"
     effect = "Allow"
@@ -21,13 +21,18 @@ data "aws_iam_policy_document" "this" {
       "events:PutEvents"
     ],
     resources = [
-      var.source_event_bus_arn
+      aws_cloudwatch_event_bus.custom_event_bus[0].arn
     ]
+
+    principals {
+      identifiers = [var.source_account_id]
+      type = "AWS"
+    }
   }
 }
 
 resource "aws_cloudwatch_event_bus_policy" "this" {
-  count          = var.source_event_bus_arn == "" ? 0 : 1
+  count          = var.source_account_id == "" ? 0 : 1
   event_bus_name = aws_cloudwatch_event_bus.custom_event_bus[0].name
   policy         = data.aws_iam_policy_document.this[0].json
 }

--- a/modules/aws/event_bridge/event_bridge_rule/main.tf
+++ b/modules/aws/event_bridge/event_bridge_rule/main.tf
@@ -19,14 +19,15 @@ data "aws_iam_policy_document" "this" {
     effect = "Allow"
     actions = [
       "events:PutEvents"
-    ],
+    ]
+
     resources = [
       aws_cloudwatch_event_bus.custom_event_bus[0].arn
     ]
 
     principals {
       identifiers = [var.source_account_id]
-      type = "AWS"
+      type        = "AWS"
     }
   }
 }
@@ -61,9 +62,9 @@ resource "aws_iam_role" "eventbridge_role" {
     Version = "2012-10-17",
     Statement = [
       {
-        Effect = "Allow"
+        Effect    = "Allow"
         Principal = { Service = "events.amazonaws.com" }
-        Action = "sts:AssumeRole"
+        Action    = "sts:AssumeRole"
       }
     ]
   })

--- a/modules/aws/event_bridge/event_bridge_rule/main.tf
+++ b/modules/aws/event_bridge/event_bridge_rule/main.tf
@@ -1,12 +1,40 @@
+terraform {
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "5.81.0"
+    }
+  }
+}
 # Create EventBridge event-bus - if required
 resource "aws_cloudwatch_event_bus" "custom_event_bus" {
   count = var.create_event_bus ? 1 : 0
-  name = var.event_bus_name
+  name  = var.event_bus_name
+}
+
+data "aws_iam_policy_document" "this" {
+  count = var.source_event_bus_arn == "" ? 0 : 1
+  statement {
+    sid    = "ActionsForResource"
+    effect = "Allow"
+    actions = [
+      "events:PutEvents"
+    ],
+    resources = [
+      var.source_event_bus_arn
+    ]
+  }
+}
+
+resource "aws_cloudwatch_event_bus_policy" "this" {
+  count          = var.source_event_bus_arn == "" ? 0 : 1
+  event_bus_name = aws_cloudwatch_event_bus.custom_event_bus[0].name
+  policy         = data.aws_iam_policy_document.this[0].json
 }
 
 resource "aws_cloudwatch_event_rule" "event_rule" {
-  name          = var.event_rule_name
-  description   = var.event_rule_description
+  name           = var.event_rule_name
+  description    = var.event_rule_description
   event_bus_name = var.event_bus_name
   event_pattern = jsonencode({
     source = var.event_sources
@@ -15,14 +43,14 @@ resource "aws_cloudwatch_event_rule" "event_rule" {
 }
 
 resource "aws_cloudwatch_event_target" "event_target" {
-  rule          = aws_cloudwatch_event_rule.event_rule.name
+  rule           = aws_cloudwatch_event_rule.event_rule.name
   event_bus_name = var.event_bus_name
-  arn           = var.target_arn
-  role_arn      = aws_iam_role.eventbridge_role.arn
+  arn            = var.target_arn
+  role_arn       = aws_iam_role.eventbridge_role.arn
 }
 
 resource "aws_iam_role" "eventbridge_role" {
-  name  = var.role_name
+  name = var.role_name
 
   assume_role_policy = jsonencode({
     Version = "2012-10-17",
@@ -37,7 +65,7 @@ resource "aws_iam_role" "eventbridge_role" {
 }
 
 resource "aws_iam_role_policy" "eventbridge_policy" {
-  role  = aws_iam_role.eventbridge_role.id
+  role = aws_iam_role.eventbridge_role.id
 
   policy = jsonencode({
     Version = "2012-10-17",

--- a/modules/aws/event_bridge/event_bridge_rule/variables.tf
+++ b/modules/aws/event_bridge/event_bridge_rule/variables.tf
@@ -37,3 +37,9 @@ variable "role_actions" {
   description = "List of actions the IAM Role should allow"
   type        = list(string)
 }
+
+variable "source_event_bus_arn" {
+  type        = string
+  description = "The Arn of the source event bus when forwarding events"
+  default     = ""
+}

--- a/modules/aws/event_bridge/event_bridge_rule/variables.tf
+++ b/modules/aws/event_bridge/event_bridge_rule/variables.tf
@@ -38,8 +38,8 @@ variable "role_actions" {
   type        = list(string)
 }
 
-variable "source_event_bus_arn" {
+variable "source_account_id" {
   type        = string
-  description = "The Arn of the source event bus when forwarding events"
+  description = "The source AWS Account ID where events are forwarded from"
   default     = ""
 }


### PR DESCRIPTION
Add resource based policy to enable forwarding of events from an Event Bus in one account to another.
Required as part of the architecture to send platform Security Hub findings to Splunk.